### PR TITLE
Update campaign docs on new params

### DIFF
--- a/campaigns.yml
+++ b/campaigns.yml
@@ -6,6 +6,8 @@
 #   start: "2018-01-31 00:00:00"
 #   end: "2018-12-31 23:59:59"
 #   trafficLimit: 10
+#   minDisplayWidth: 0
+#   maxDisplayWidth: 2000
 #   buckets:
 #   - name: B18WPDE_01_180131_ctrl
 #     banners:
@@ -26,6 +28,8 @@
 # start: Start date, in either YYYY-MM-DD or YYYY-MM-DD HH:MM:SS format.
 # end: End date, in either YYYY-MM-DD or YYYY-MM-DD HH:MM:SS format.
 # trafficLimit: Traffic limit in percent
+# minDisplayWidth: (in pixel, can be null) the campaign will only be displayed for client viewport sizes above this value
+# maxDisplayWidth: (in pixel, can be null) the campaign will only be displayed for client viewport sizes below this value
 # buckets: List of buckets which consist of two values:
 #   name: The name used to identify the bucket.
 #     Naming schema of buckets follows campaign name plus a unique bucket suffix. The usual practice is "_ctrl" for "control" and "_var" for "variant" test groups.


### PR DESCRIPTION
Since the implementation of this ticket https://phabricator.wikimedia.org/T253535
the wikipedia.de banner server allows to configure a viewport range for campaigns, 
so for example mobile and desktop campaigns are possible now.